### PR TITLE
feat(Availability): add anonymous sessionId availability check

### DIFF
--- a/src/Controllers/AvailabilityController.cs
+++ b/src/Controllers/AvailabilityController.cs
@@ -25,5 +25,14 @@ namespace civica_service.Controllers
 
             return Ok();
         }
+
+        [HttpGet]
+        [Route("get-anonymous-availability")]
+        public async Task<IActionResult> GetAnonymousAvailability()
+        {
+            await _sessionProvider.GetAnonymousSessionId();
+
+            return Ok();
+        }
     }
 }

--- a/src/Helpers/SessionProvider/ISessionProvider.cs
+++ b/src/Helpers/SessionProvider/ISessionProvider.cs
@@ -4,6 +4,7 @@ namespace civica_service.Helpers.SessionProvider
 {
     public interface ISessionProvider
     {
+        Task<string> GetAnonymousSessionId();
         Task<string> GetSessionId();
         Task<string> GetSessionId(string personReference);
     }

--- a/src/Helpers/SessionProvider/Models/SessionIdModel.cs
+++ b/src/Helpers/SessionProvider/Models/SessionIdModel.cs
@@ -16,4 +16,17 @@ namespace civica_service.Helpers.SessionProvider.Models
         [XmlElement("ErrorCode")]
         public ErrorCode ErrorCode { get; set; }
     }
+
+    [XmlRoot("StandardInfo")]
+    public class AnonymousSessionIdModel
+    {
+        [XmlElement("SessionID")]
+        public string SessionID { get; set; }
+    }
+
+    public class AnonymousResult
+    {
+        [XmlElement("SessionID")]
+        public string SessionID { get; set; }
+    }
 }

--- a/src/Helpers/SessionProvider/SessionProvider.cs
+++ b/src/Helpers/SessionProvider/SessionProvider.cs
@@ -34,6 +34,26 @@ namespace civica_service.Helpers.SessionProvider
             _xmlParser = xmlParser;
         }
 
+        public async Task<string> GetAnonymousSessionId()
+        {
+            var url = _queryBuilder
+                .Add("docid", "login")
+                .Build();
+
+            var response = await _gateway.GetAsync(url);
+
+            if (response.StatusCode != HttpStatusCode.OK)
+                throw new Exception($"Civica is unavailable. Responded with status code: {response.StatusCode}");
+
+            var xmlResponse = await response.Content.ReadAsStringAsync();
+
+            var deserializedResponse = _xmlParser.DeserializeXmlStringToType<AnonymousSessionIdModel>(xmlResponse, "StandardInfo");
+
+            var sessionId = deserializedResponse.SessionID;
+
+            return sessionId;
+        }
+
         public async Task<string> GetSessionId()
         {
             string cacheKey = $"{ECacheKeys.SessionId}-Availability";


### PR DESCRIPTION
New endpoint to anonymously check the Civica brokers are up and working (does not require successful login)