### PR TITLE
chore(CivicaService): add excpetion handling for benefits payment, ad…

### DIFF
--- a/src/Services/CivicaService.cs
+++ b/src/Services/CivicaService.cs
@@ -368,7 +368,7 @@ namespace civica_service.Services
             }
             catch (Exception ex)
             {
-                throw new Exception($"Failed to deserialize XML - Person reference: {personReference}, Account reference: {accountReference}, Response: {responseContent}", ex.InnerException);
+                throw new Exception($"CivicaService:: GetCouncilTaxDetails:: Failed to deserialize XML - Person reference: {personReference}, Account reference: {accountReference}, Response: {responseContent}", ex.InnerException);
             }
 
             try
@@ -377,7 +377,7 @@ namespace civica_service.Services
             }
             catch (Exception ex)
             {
-                throw new Exception($"Failed to cache response due to model error - Person reference: {personReference}, Account reference: {accountReference}, Exception: {ex.Message}", ex.InnerException);
+                throw new Exception($"CivicaService:: GetCouncilTaxDetails:: Failed to cache response due to model error - Person reference: {personReference}, Account reference: {accountReference}, Exception: {ex.Message}", ex.InnerException);
             }
 
             return parsedResponse;

--- a/tests/Service/CivicaServiceTests.cs
+++ b/tests/Service/CivicaServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using civica_service.Helpers.QueryBuilder;
 using civica_service.Helpers.SessionProvider;
@@ -293,6 +294,19 @@ namespace civica_service_tests.Service
             _mockQueryBuilder.Verify(_ => _.Add("type", "prp"), Times.Once);
             _mockQueryBuilder.Verify(_ => _.Build(), Times.Once);
             _mockGateway.Verify(_ => _.GetAsync(It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async void GetHousingBenefitPaymentHistory_ShouldThrowExeception_IfPaymentListIsNull()
+        {
+            // Arrange
+            _mockXmlParser
+                .Setup(_ => _.DeserializeXmlStringToType<PaymentDetailsResponse>(It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Returns(new PaymentDetailsResponse());
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(() => _civicaService.GetHousingBenefitPaymentHistory(""));
         }
 
         [Fact]

--- a/tests/Service/CivicaServiceTests.cs
+++ b/tests/Service/CivicaServiceTests.cs
@@ -381,6 +381,19 @@ namespace civica_service_tests.Service
         }
 
         [Fact]
+        public async void GetCouncilTaxBenefitPaymentHistory_ShouldThrowExeception_IfPaymentListIsNull()
+        {
+            // Arrange
+            _mockXmlParser
+                .Setup(_ => _.DeserializeXmlStringToType<PaymentDetailsResponse>(It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Returns(new PaymentDetailsResponse());
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(() => _civicaService.GetCouncilTaxBenefitPaymentHistory(""));
+        }
+
+        [Fact]
         public async void GetDocuments_ShouldCallCacheProvider_WithGetStringAsync()
         {
             // Arrange


### PR DESCRIPTION
…d try catch in GetCouncilTaxDetails

* Add null checks and throws for null paymentLists (theoretically users shouldn't be able to hit these endpoints if they don't have benefits but saved old bookmarks may still make the call)
* Add a try/catch around saving the response in GetCouncilTaxDetails due to a known issue with commas in a specific Civica field, this will help us identify accounts that have issues
* One unit test added, more will follow at a later date